### PR TITLE
Fixed incomplete SSR hydration

### DIFF
--- a/src/main/enableSSRHydration.ts
+++ b/src/main/enableSSRHydration.ts
@@ -36,8 +36,10 @@ export function enableSSRHydration(executorManager: ExecutorManager, options: SS
   }
 
   window.__REACT_EXECUTOR_SSR_STATE__ = {
-    push(chunk) {
-      executorManager.hydrate(stateParser(chunk));
+    push() {
+      for (let i = 0; i < arguments.length; ++i) {
+        executorManager.hydrate(stateParser(arguments[i]));
+      }
     },
   };
 }

--- a/src/main/global.d.ts
+++ b/src/main/global.d.ts
@@ -4,6 +4,6 @@ declare global {
   const __REACT_EXECUTOR_DEVTOOLS__: { plugin: ExecutorPlugin } | undefined;
 
   interface Window {
-    __REACT_EXECUTOR_SSR_STATE__?: { push(stateStr: string): void };
+    __REACT_EXECUTOR_SSR_STATE__?: { push(...stateStrs: string[]): void };
   }
 }

--- a/src/main/ssr/ReadableSSRExecutorManager.ts
+++ b/src/main/ssr/ReadableSSRExecutorManager.ts
@@ -23,7 +23,7 @@ export class ReadableSSRExecutorManager extends SSRExecutorManager implements Re
 
         const hydrationChunk = this.nextHydrationChunk();
 
-        if (hydrationChunk !== undefined) {
+        if (hydrationChunk !== '') {
           controller.enqueue(hydrationChunk);
         }
       },

--- a/src/main/ssr/SSRExecutorManager.ts
+++ b/src/main/ssr/SSRExecutorManager.ts
@@ -58,10 +58,10 @@ export class SSRExecutorManager extends ExecutorManager {
   }
 
   /**
-   * Returns a chunk that hydrates the client with the state accumulated during SSR, or `undefined` if there are no
+   * Returns a chunk that hydrates the client with the state accumulated during SSR, or an empty string if there are no
    * state changes since the last time {@link nextHydrationChunk} was called.
    */
-  nextHydrationChunk(): string | undefined {
+  nextHydrationChunk(): string {
     const stateStrs = [];
 
     for (const executor of this._executors.values()) {
@@ -75,7 +75,7 @@ export class SSRExecutorManager extends ExecutorManager {
     }
 
     if (stateStrs.length === 0) {
-      return;
+      return '';
     }
 
     return (

--- a/src/main/ssr/SSRExecutorManager.ts
+++ b/src/main/ssr/SSRExecutorManager.ts
@@ -62,25 +62,25 @@ export class SSRExecutorManager extends ExecutorManager {
    * state changes since the last time {@link nextHydrationChunk} was called.
    */
   nextHydrationChunk(): string | undefined {
-    const sources = [];
+    const stateStrs = [];
 
     for (const executor of this._executors.values()) {
       const hydratedVersion = this._hydratedVersions.get(executor);
 
       if ((hydratedVersion === undefined || hydratedVersion !== executor.version) && this._executorFilter(executor)) {
-        sources.push(JSON.stringify(this._stateStringifier(executor.toJSON())));
+        stateStrs.push(JSON.stringify(this._stateStringifier(executor.toJSON())));
 
         this._hydratedVersions.set(executor, executor.version);
       }
     }
 
-    if (sources.length === 0) {
+    if (stateStrs.length === 0) {
       return;
     }
 
     return (
       '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push(' +
-      sources.join(',') +
+      stateStrs.join(',') +
       ');var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
     );
   }

--- a/src/main/ssr/node/PipeableSSRExecutorManager.ts
+++ b/src/main/ssr/node/PipeableSSRExecutorManager.ts
@@ -29,11 +29,12 @@ export class PipeableSSRExecutorManager extends SSRExecutorManager {
 
           const hydrationChunk = this.nextHydrationChunk();
 
-          if (hydrationChunk !== undefined) {
+          if (hydrationChunk !== '') {
             stream.write(hydrationChunk, callback);
-          } else {
-            callback();
+            return;
           }
+
+          callback();
         });
       },
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -80,18 +80,18 @@ export interface ExecutorEvent<Value = any> {
    * See {@link ExecutorEvent} for more details.
    */
   type:
-    | 'plugin_configured'
     | 'attached'
+    | 'detached'
     | 'activated'
-    | 'annotated'
+    | 'deactivated'
     | 'pending'
     | 'fulfilled'
     | 'rejected'
     | 'aborted'
     | 'cleared'
     | 'invalidated'
-    | 'deactivated'
-    | 'detached'
+    | 'annotated'
+    | 'plugin_configured'
     | (string & {});
 
   /**

--- a/src/test/enableSSRHydration.test.ts
+++ b/src/test/enableSSRHydration.test.ts
@@ -28,6 +28,41 @@ describe('enableSSRHydration', () => {
     expect(executor.settledAt).toBe(50);
   });
 
+  test('hydrates multiple executors that are added after', () => {
+    const manager = new ExecutorManager();
+
+    enableSSRHydration(manager);
+
+    window.__REACT_EXECUTOR_SSR_STATE__!.push(
+      JSON.stringify({
+        key: 'xxx',
+        isFulfilled: true,
+        value: 111,
+        reason: undefined,
+        settledAt: 50,
+        invalidatedAt: 0,
+        annotations: {},
+      }),
+      JSON.stringify({
+        key: 'yyy',
+        isFulfilled: true,
+        value: 222,
+        reason: undefined,
+        settledAt: 100,
+        invalidatedAt: 0,
+        annotations: {},
+      })
+    );
+
+    const executor1 = manager.getOrCreate('xxx');
+    const executor2 = manager.getOrCreate('yyy');
+
+    expect(executor1.value).toBe(111);
+    expect(executor1.settledAt).toBe(50);
+    expect(executor2.value).toBe(222);
+    expect(executor2.settledAt).toBe(100);
+  });
+
   test('hydrates an executor that was added before', () => {
     window.__REACT_EXECUTOR_SSR_STATE__ = [
       JSON.stringify({


### PR DESCRIPTION
- `SSRExecutorManager.nextHydrationChunk()` always returns a string. If there are no changes then an empty string is returned instead of a `<script>` tag.

- Multiple executors are now successfully hydrated from a single hydration chunk.