### PR TITLE
Added abortPending and rejectPending plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ npm install --save-prod react-executor
 🔌&ensp;[**Plugins**](#plugins)
 
 - [`abortDeactivated`](#abortdeactivated)
+- [`abortPending`](#abortpending)
 - [`abortWhen`](#abortwhen)
 - [`bindAll`](#bindall)
 - [`detachDeactivated`](#detachdeactivated)
 - [`invalidateAfter`](#invalidateafter)
 - [`invalidateByPeers`](#invalidatebypeers)
 - [`invalidatePeers`](#invalidatepeers)
+- [`resolvePending`](#resolvepending)
 - [`resolveWhen`](#resolvewhen)
 - [`retryFulfilled`](#retryfulfilled)
 - [`retryInvalidated`](#retryinvalidated)
@@ -812,6 +814,20 @@ executor.deactivate();
 `abortDeactivated` has a single argument: the delay after which the task should be aborted. If an executor is
 re-activated during this delay, the task won't be aborted. 
 
+## `abortPending`
+
+[Aborts the pending task](#abort-a-task)
+with [`TimeoutError`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#timeouterror) if the task execution
+took longer then the given timeout.
+
+```ts
+import abortPending from 'react-executor/plugin/abortPending';
+
+const executor = useExecutor('test', heavyTask, [
+  abortPending(10_000)
+]);
+```
+
 ## `abortWhen`
 
 [Aborts the pending task](#abort-a-task) depending on boolean values pushed by an
@@ -950,6 +966,20 @@ const breadExecutor = useExecutor('bread', 'Focaccia');
 
 // breadExecutor is invalidated
 cheeseExecutor.resolve('Mozzarella');
+```
+
+## `resolvePending`
+
+[Aborts the pending task](#abort-a-task) and [rejects the executor](#settle-an-executor)
+with [`TimeoutError`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#timeouterror) if the task execution
+took longer then the given timeout.
+
+```ts
+import rejectPending from 'react-executor/plugin/rejectPending';
+
+const executor = useExecutor('test', heavyTask, [
+  rejectPending(10_000)
+]);
 ```
 
 ## `resolveWhen`

--- a/README.md
+++ b/README.md
@@ -925,7 +925,10 @@ Invalidates the executor result if another executor with a matching key is fulfi
 ```ts
 import invalidateByPeers from 'react-executor/plugin/invalidateByPeers';
 
-const cheeseExecutor = useExecutor('cheese', 'Burrata', [invalidateByPeers(/bread/)]);
+const cheeseExecutor = useExecutor('cheese', 'Burrata', [
+  invalidateByPeers(executor => executor.key === 'bread')
+]);
+
 const breadExecutor = useExecutor('bread');
 
 // cheeseExecutor is invalidated
@@ -939,7 +942,10 @@ Invalidates peer executors with matching keys if the executor is fulfilled or in
 ```ts
 import invalidatePeers from 'react-executor/plugin/invalidatePeers';
 
-const cheeseExecutor = useExecutor('cheese', 'Burrata', [invalidatePeers(/bread/)]);
+const cheeseExecutor = useExecutor('cheese', 'Burrata', [
+  invalidatePeers(executor => executor.key === 'bread')
+]);
+
 const breadExecutor = useExecutor('bread', 'Focaccia');
 
 // breadExecutor is invalidated
@@ -1058,7 +1064,7 @@ const fetchCheese: ExecutorTask = async (signal, executor) => {
 };
 
 const cheeseExecutor = useExecutor('cheese', fetchCheese, [
-  invalidateByPeers('bread'),
+  invalidateByPeers(executor => executor.key === 'bread'),
   retryInvalidated(),
 ]);
 

--- a/src/main/plugin/abortPending.ts
+++ b/src/main/plugin/abortPending.ts
@@ -1,0 +1,53 @@
+/**
+ * The plugin that aborts the pending task with {@link !DOMException TimeoutError} if the task execution took longer
+ * then the given timeout.
+ *
+ * ```ts
+ * import abortPending from 'react-executor/plugin/abortPending';
+ *
+ * const executor = useExecutor('test', heavyTask, [
+ *   abortPending(10_000)
+ * ]);
+ * ```
+ *
+ * @module plugin/abortPending
+ */
+
+import type { ExecutorPlugin, PluginConfiguredPayload } from '../types';
+import { TimeoutError } from '../utils';
+
+/**
+ * Aborts the pending task with {@link !DOMException TimeoutError} if the task execution took longer then the given
+ * timeout.
+ *
+ * @param ms The timeout in milliseconds after which the task is aborted.
+ */
+export default function abortPending(ms: number): ExecutorPlugin {
+  return executor => {
+    let timer: NodeJS.Timeout;
+
+    executor.subscribe(event => {
+      switch (event.type) {
+        case 'pending':
+          clearTimeout(timer);
+
+          timer = setTimeout(() => {
+            executor.abort(TimeoutError('The task execution took too long'));
+          }, ms);
+          break;
+
+        case 'fulfilled':
+        case 'rejected':
+        case 'aborted':
+        case 'detached':
+          clearTimeout(timer);
+          break;
+      }
+    });
+
+    executor.publish<PluginConfiguredPayload>('plugin_configured', {
+      type: 'abortPending',
+      options: { ms },
+    });
+  };
+}

--- a/src/main/plugin/abortWhen.ts
+++ b/src/main/plugin/abortWhen.ts
@@ -54,6 +54,7 @@ export default function abortWhen(observable: Observable<boolean>, ms = 0): Exec
           break;
 
         case 'detached':
+          clearTimeout(timer);
           unsubscribe();
           break;
       }

--- a/src/main/plugin/rejectPending.ts
+++ b/src/main/plugin/rejectPending.ts
@@ -1,0 +1,53 @@
+/**
+ * The plugin that aborts the pending task and rejects the executor with {@link !DOMException TimeoutError} if the task
+ * execution took longer then the given timeout.
+ *
+ * ```ts
+ * import rejectPending from 'react-executor/plugin/rejectPending';
+ *
+ * const executor = useExecutor('test', heavyTask, [
+ *   rejectPending(10_000)
+ * ]);
+ * ```
+ *
+ * @module plugin/rejectPending
+ */
+
+import type { ExecutorPlugin, PluginConfiguredPayload } from '../types';
+import { TimeoutError } from '../utils';
+
+/**
+ * Aborts the pending task and rejects the executor with {@link !DOMException TimeoutError} if the task execution took
+ * longer then the given timeout.
+ *
+ * @param ms The timeout in milliseconds after which the executor is rejected.
+ */
+export default function rejectPending(ms: number): ExecutorPlugin {
+  return executor => {
+    let timer: NodeJS.Timeout;
+
+    executor.subscribe(event => {
+      switch (event.type) {
+        case 'pending':
+          timer = setTimeout(() => {
+            const error = TimeoutError('The task execution took too long');
+            executor.abort(error);
+            executor.reject(error);
+          }, ms);
+          break;
+
+        case 'fulfilled':
+        case 'rejected':
+        case 'aborted':
+        case 'detached':
+          clearTimeout(timer);
+          break;
+      }
+    });
+
+    executor.publish<PluginConfiguredPayload>('plugin_configured', {
+      type: 'rejectPending',
+      options: { ms },
+    });
+  };
+}

--- a/src/main/plugin/retryFulfilled.ts
+++ b/src/main/plugin/retryFulfilled.ts
@@ -47,6 +47,7 @@ export default function retryFulfilled<Value = any>(
         case 'rejected':
         case 'aborted':
         case 'deactivated':
+        case 'detached':
           index = 0;
           clearTimeout(timer);
           break;

--- a/src/main/plugin/retryRejected.ts
+++ b/src/main/plugin/retryRejected.ts
@@ -47,6 +47,7 @@ export default function retryRejected<Value = any>(
         case 'fulfilled':
         case 'aborted':
         case 'deactivated':
+        case 'detached':
           index = 0;
           clearTimeout(timer);
           break;

--- a/src/main/plugin/retryWhen.ts
+++ b/src/main/plugin/retryWhen.ts
@@ -65,6 +65,7 @@ export default function retryWhen(observable: Observable<boolean>, ms = 0): Exec
           break;
 
         case 'detached':
+          clearTimeout(timer);
           unsubscribe();
           break;
       }

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -3,3 +3,7 @@ export function noop() {}
 export function AbortError(message: string): Error {
   return typeof DOMException !== 'undefined' ? new DOMException(message, 'AbortError') : Error(message);
 }
+
+export function TimeoutError(message: string): Error {
+  return typeof DOMException !== 'undefined' ? new DOMException(message, 'TimeoutError') : Error(message);
+}

--- a/src/test/plugin/abortPending.test.ts
+++ b/src/test/plugin/abortPending.test.ts
@@ -1,0 +1,30 @@
+import { delay } from 'parallel-universe';
+import { ExecutorManager } from '../../main';
+import abortPending from '../../main/plugin/abortPending';
+import { TimeoutError } from '../../main/utils';
+
+describe('abortPending', () => {
+  let manager: ExecutorManager;
+
+  beforeEach(() => {
+    manager = new ExecutorManager();
+  });
+
+  test('aborts the pending task', async () => {
+    const executor = manager.getOrCreate('xxx', undefined, [abortPending(0)]);
+
+    const promise = executor.execute(() => delay(100));
+
+    await expect(promise).rejects.toEqual(TimeoutError('The task execution took too long'));
+    expect(executor.isRejected).toBe(false);
+  });
+
+  test('does not abort the pending when it is settled before the timeout', async () => {
+    const executor = manager.getOrCreate('xxx', undefined, [abortPending(100)]);
+
+    const promise = executor.execute(() => delay(0, 'aaa'));
+
+    await expect(promise).resolves.toEqual('aaa');
+    expect(executor.isRejected).toBe(false);
+  });
+});

--- a/src/test/plugin/rejectPending.test.ts
+++ b/src/test/plugin/rejectPending.test.ts
@@ -1,0 +1,31 @@
+import { delay } from 'parallel-universe';
+import { ExecutorManager } from '../../main';
+import rejectPending from '../../main/plugin/rejectPending';
+import { TimeoutError } from '../../main/utils';
+
+describe('rejectPending', () => {
+  let manager: ExecutorManager;
+
+  beforeEach(() => {
+    manager = new ExecutorManager();
+  });
+
+  test('aborts the pending task and rejects the executor', async () => {
+    const executor = manager.getOrCreate('xxx', undefined, [rejectPending(0)]);
+
+    const promise = executor.execute(() => delay(100));
+
+    await expect(promise).rejects.toEqual(TimeoutError('The task execution took too long'));
+    expect(executor.isRejected).toBe(true);
+    expect(executor.reason).toEqual(TimeoutError('The task execution took too long'));
+  });
+
+  test('does not abort the pending and reject the executor when it is settled before the timeout', async () => {
+    const executor = manager.getOrCreate('xxx', undefined, [rejectPending(100)]);
+
+    const promise = executor.execute(() => delay(0, 'aaa'));
+
+    await expect(promise).resolves.toEqual('aaa');
+    expect(executor.isRejected).toBe(false);
+  });
+});


### PR DESCRIPTION
Added `abortPending` and `rejectPending` plugins that abort the pending task if the execution takes too long:

```ts
import abortPending from 'react-executor/plugin/abortPending';

const executor = useExecutor('test', heavyTask, [
  abortPending(10_000)
]);
```