### PR TITLE
Added nextHydrationScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@testing-library/react": "^15.0.5",
         "@types/jest": "^29.5.12",
         "@types/react": "^18.3.1",
-        "@types/use-sync-external-store": "^0.0.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.2.5",
@@ -1767,12 +1766,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "dev": true
     },
     "node_modules/@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "@testing-library/react": "^15.0.5",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.3.1",
-    "@types/use-sync-external-store": "^0.0.6",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.2.5",

--- a/src/main/enableSSRHydration.ts
+++ b/src/main/enableSSRHydration.ts
@@ -18,10 +18,12 @@ export interface SSRHydrationOptions {
  *
  * **Note:** SSR hydration can be enabled for one executor only.
  *
- * @param executorManager The executor manager for which SSR hydration must be enabled.
+ * @param manager The executor manager for which SSR hydration must be enabled.
  * @param options Additional options.
+ * @returns The provided executor manager.
+ * @template T The executor manager.
  */
-export function enableSSRHydration(executorManager: ExecutorManager, options: SSRHydrationOptions = {}): void {
+export function enableSSRHydration<T extends ExecutorManager>(manager: T, options: SSRHydrationOptions = {}): T {
   const { stateParser = JSON.parse } = options;
 
   const ssrState =
@@ -29,7 +31,7 @@ export function enableSSRHydration(executorManager: ExecutorManager, options: SS
 
   if (Array.isArray(ssrState)) {
     for (const stateStr of ssrState) {
-      executorManager.hydrate(stateParser(stateStr));
+      manager.hydrate(stateParser(stateStr));
     }
   } else if (ssrState !== undefined) {
     throw new Error('SSR hydration already enabled');
@@ -38,8 +40,10 @@ export function enableSSRHydration(executorManager: ExecutorManager, options: SS
   window.__REACT_EXECUTOR_SSR_STATE__ = {
     push() {
       for (let i = 0; i < arguments.length; ++i) {
-        executorManager.hydrate(stateParser(arguments[i]));
+        manager.hydrate(stateParser(arguments[i]));
       }
     },
   };
+
+  return manager;
 }

--- a/src/main/useExecutorSuspense.ts
+++ b/src/main/useExecutorSuspense.ts
@@ -6,9 +6,9 @@ import { noop } from './utils';
  *
  * @param executors Executors to wait for.
  * @returns Provided executors.
- * @template Executors Executors to wait for.
+ * @template T Executors to wait for.
  */
-export function useExecutorSuspense(executors: Executor | Executor[]): void {
+export function useExecutorSuspense<T extends Executor | Executor[]>(executors: T): T {
   if (Array.isArray(executors)) {
     const promises = executors.reduce(reducePending, null);
 
@@ -18,6 +18,7 @@ export function useExecutorSuspense(executors: Executor | Executor[]): void {
   } else if (executors.isPending) {
     throw executors.getOrAwait().then(noop, noop);
   }
+  return executors;
 }
 
 function reducePending(promises: PromiseLike<unknown>[] | null, executor: Executor): PromiseLike<unknown>[] | null {

--- a/src/test/enableSSRHydration.test.ts
+++ b/src/test/enableSSRHydration.test.ts
@@ -5,6 +5,12 @@ describe('enableSSRHydration', () => {
     window.__REACT_EXECUTOR_SSR_STATE__ = undefined;
   });
 
+  test('returns the provided executor', () => {
+    const manager = new ExecutorManager();
+
+    expect(enableSSRHydration(manager)).toBe(manager);
+  });
+
   test('hydrates an executor that is added after', () => {
     const manager = new ExecutorManager();
 

--- a/src/test/ssr/SSRExecutorManager.test.ts
+++ b/src/test/ssr/SSRExecutorManager.test.ts
@@ -4,55 +4,55 @@ import { noop } from '../../main/utils';
 Date.now = () => 50;
 
 describe('SSRExecutorManager', () => {
-  describe('nextHydrationChunk', () => {
+  describe('nextHydrationScript', () => {
     test('returns undefined if there no changes in state', () => {
       const manager = new SSRExecutorManager();
 
       manager.getOrCreate('xxx');
 
-      expect(manager.nextHydrationChunk()).toBe('');
+      expect(manager.nextHydrationScript()).toBe('');
     });
 
-    test('returns the hydration chunk for a single executor', async () => {
+    test('returns the hydration script for a single executor', async () => {
       const manager = new SSRExecutorManager();
 
       const executor = manager.getOrCreate('xxx');
 
-      expect(manager.nextHydrationChunk()).toBe('');
+      expect(manager.nextHydrationScript()).toBe('');
 
       const promise = executor.execute(() => 111);
 
-      expect(manager.nextHydrationChunk()).toBe('');
+      expect(manager.nextHydrationScript()).toBe('');
 
       await promise;
 
-      expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
+      expect(manager.nextHydrationScript()).toBe(
+        '(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);'
       );
     });
 
-    test('returns the hydration chunk for multiple executors', async () => {
+    test('returns the hydration script for multiple executors', async () => {
       const manager = new SSRExecutorManager();
 
       const executor1 = manager.getOrCreate('xxx');
       const executor2 = manager.getOrCreate('yyy');
 
-      expect(manager.nextHydrationChunk()).toBe('');
+      expect(manager.nextHydrationScript()).toBe('');
 
       const promise1 = executor1.execute(() => 111);
       const promise2 = executor2.execute(() => 222);
 
-      expect(manager.nextHydrationChunk()).toBe('');
+      expect(manager.nextHydrationScript()).toBe('');
 
       await promise1;
       await promise2;
 
-      expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}","{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
+      expect(manager.nextHydrationScript()).toBe(
+        '(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}","{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);'
       );
     });
 
-    test('returns only changed executor states in consequent hydration chunks', async () => {
+    test('returns only changed executor states in consequent hydration scripts', async () => {
       const manager = new SSRExecutorManager();
 
       const executor1 = manager.getOrCreate('xxx');
@@ -60,16 +60,16 @@ describe('SSRExecutorManager', () => {
 
       await executor1.execute(() => 111);
 
-      manager.nextHydrationChunk();
+      manager.nextHydrationScript();
 
       const promise = executor2.execute(() => 222);
 
-      expect(manager.nextHydrationChunk()).toBe('');
+      expect(manager.nextHydrationScript()).toBe('');
 
       await promise;
 
-      expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
+      expect(manager.nextHydrationScript()).toBe(
+        '(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);'
       );
     });
 
@@ -81,7 +81,7 @@ describe('SSRExecutorManager', () => {
         .execute(() => Promise.reject('expected'))
         .catch(noop);
 
-      expect(manager.nextHydrationChunk()).toBe('');
+      expect(manager.nextHydrationScript()).toBe('');
     });
 
     test('respects executorFilter option', async () => {
@@ -94,8 +94,8 @@ describe('SSRExecutorManager', () => {
         .execute(() => Promise.reject('expected'))
         .catch(noop);
 
-      expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":false,\\"reason\\":\\"expected\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
+      expect(manager.nextHydrationScript()).toBe(
+        '(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":false,\\"reason\\":\\"expected\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);'
       );
     });
 
@@ -108,7 +108,7 @@ describe('SSRExecutorManager', () => {
 
       manager.getOrCreate('xxx', 111);
 
-      manager.nextHydrationChunk();
+      manager.nextHydrationScript();
 
       expect(stateStringifierMock).toHaveBeenCalledTimes(1);
       expect(stateStringifierMock).toHaveBeenNthCalledWith(1, {
@@ -127,10 +127,30 @@ describe('SSRExecutorManager', () => {
 
       manager.getOrCreate('xxx', '<script src="https://xxx.yyy"></script>');
 
-      const chunk = manager.nextHydrationChunk();
+      const source = manager.nextHydrationScript();
 
-      expect(chunk).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":\\"\\u003Cscript src=\\\\\\"https://xxx.yyy\\\\\\">\\u003C/script>\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
+      expect(source).toBe(
+        '(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":\\"\\u003Cscript src=\\\\\\"https://xxx.yyy\\\\\\">\\u003C/script>\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);'
+      );
+    });
+  });
+
+  describe('nextHydrationChunk', () => {
+    test('returns undefined if there no changes in state', () => {
+      const manager = new SSRExecutorManager();
+
+      manager.getOrCreate('xxx');
+
+      expect(manager.nextHydrationChunk()).toBe('');
+    });
+
+    test('returns the hydration chunk for a single executor', async () => {
+      const manager = new SSRExecutorManager();
+
+      await manager.getOrCreate('xxx').execute(() => 111);
+
+      expect(manager.nextHydrationChunk()).toBe(
+        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
       );
     });
 

--- a/src/test/ssr/SSRExecutorManager.test.ts
+++ b/src/test/ssr/SSRExecutorManager.test.ts
@@ -27,7 +27,7 @@ describe('SSRExecutorManager', () => {
       await promise;
 
       expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
       );
     });
 
@@ -48,7 +48,7 @@ describe('SSRExecutorManager', () => {
       await promise2;
 
       expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}","{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}","{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
       );
     });
 
@@ -69,7 +69,7 @@ describe('SSRExecutorManager', () => {
       await promise;
 
       expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"yyy\\",\\"isFulfilled\\":true,\\"value\\":222,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
       );
     });
 
@@ -95,7 +95,7 @@ describe('SSRExecutorManager', () => {
         .catch(noop);
 
       expect(manager.nextHydrationChunk()).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":false,\\"reason\\":\\"expected\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":false,\\"reason\\":\\"expected\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
       );
     });
 
@@ -130,7 +130,7 @@ describe('SSRExecutorManager', () => {
       const chunk = manager.nextHydrationChunk();
 
       expect(chunk).toBe(
-        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":\\"\\u003Cscript src=\\\\\\"https://xxx.yyy\\\\\\">\\u003C/script>\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+        '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":\\"\\u003Cscript src=\\\\\\"https://xxx.yyy\\\\\\">\\u003C/script>\\",\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
       );
     });
 
@@ -142,7 +142,7 @@ describe('SSRExecutorManager', () => {
       const chunk = manager.nextHydrationChunk();
 
       expect(chunk).toBe(
-        '<script nonce="111">(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+        '<script nonce="111">(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
       );
     });
   });

--- a/src/test/ssr/node/PipeableSSRExecutorManager.test.ts
+++ b/src/test/ssr/node/PipeableSSRExecutorManager.test.ts
@@ -27,7 +27,7 @@ describe('PipeableSSRExecutorManager', () => {
     expect(writeMock).toHaveBeenNthCalledWith(1, 'aaa');
     expect(writeMock).toHaveBeenNthCalledWith(
       2,
-      '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+      '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
     );
   });
 
@@ -54,7 +54,7 @@ describe('PipeableSSRExecutorManager', () => {
     expect(writeMock).toHaveBeenNthCalledWith(1, 'aaa');
     expect(writeMock).toHaveBeenNthCalledWith(
       2,
-      '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e)</script>'
+      '<script>(window.__REACT_EXECUTOR_SSR_STATE__=window.__REACT_EXECUTOR_SSR_STATE__||[]).push("{\\"key\\":\\"xxx\\",\\"isFulfilled\\":true,\\"value\\":111,\\"annotations\\":{},\\"settledAt\\":50,\\"invalidatedAt\\":0}");var e=document.currentScript;e&&e.parentNode.removeChild(e);</script>'
     );
     expect(writeMock).toHaveBeenNthCalledWith(3, 'bbb');
   });


### PR DESCRIPTION
`SSRExecutorManager.nextHydrationScript()` returns a script source that hydrates the client with the state accumulated during SSR, or an empty string if there are no state changes since the last time `nextHydrationScript` was called.