### PR TITLE
Fixed synchronizeStorage plugin

### DIFF
--- a/rewrite.mjs
+++ b/rewrite.mjs
@@ -4,6 +4,9 @@ process.chdir(process.argv[2]);
 
 for (const file of fs.readdirSync('.', { recursive: true })) {
   if (file.endsWith('.js')) {
-    fs.writeFileSync(file.replaceAll('.js', '.mjs'), fs.readFileSync(file, 'utf8').replaceAll(".js'", ".mjs'"));
+    fs.writeFileSync(
+      file.slice(0, -3) + '.mjs',
+      fs.readFileSync(file, 'utf8').replace(/(['"]\.[^'"]+)\.js/g, '$1.mjs')
+    );
   }
 }

--- a/src/main/ExecutorImpl.ts
+++ b/src/main/ExecutorImpl.ts
@@ -22,7 +22,7 @@ export class ExecutorImpl<Value = any> implements Executor {
   settledAt = 0;
   invalidatedAt = 0;
   isFulfilled = false;
-  annotations: ExecutorAnnotations = Object.create(null);
+  annotations: ExecutorAnnotations = {};
   version = 0;
   promise: AbortablePromise<Value> | null = null;
 

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -118,7 +118,7 @@ export interface ExecutorEvent<Value = any> {
 }
 
 /**
- * The event that can be published by an executor.
+ * The details of an event that can be published by an executor.
  */
 export interface PartialExecutorEvent {
   /**

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -380,7 +380,7 @@ export interface Executor<Value = any> extends ReadonlyExecutor<Value> {
   activate(): () => void;
 
   /**
-   * Publishes the {@link event} for subscribers of the executor and its manager.
+   * Publishes the event for subscribers of the executor and its manager.
    *
    * @param event The event to publish.
    */

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -35,3 +35,9 @@ export function isShallowEqual(a: any, b: any): boolean {
 
   return true;
 }
+
+export function throwUnhandled(error: unknown): void {
+  setTimeout(() => {
+    throw error;
+  }, 0);
+}

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -14,6 +14,24 @@ export function isObjectLike(value: any): value is object {
   return value !== null && typeof value === 'object';
 }
 
-export function getKeyCount(value: object): number {
-  return Object.keys(value).length;
+export function isShallowEqual(a: object, b: object): boolean;
+
+export function isShallowEqual(a: any, b: any): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  const keys = Object.keys(a);
+
+  if (keys.length !== Object.keys(b).length) {
+    return false;
+  }
+
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key) || !Object.is(a[key], b[key])) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/src/test/plugin/synchronizeStorage.test.ts
+++ b/src/test/plugin/synchronizeStorage.test.ts
@@ -139,14 +139,14 @@ test('resolves an executor with an invalidated storage item', () => {
 
   expect(listenerMock).toHaveBeenCalledTimes(4);
   expect(listenerMock).toHaveBeenNthCalledWith(1, { type: 'fulfilled', target: executor, version: 1 });
-  expect(listenerMock).toHaveBeenNthCalledWith(2, { type: 'invalidated', target: executor, version: 2 });
+  expect(listenerMock).toHaveBeenNthCalledWith(2, { type: 'invalidated', target: executor, version: 1 });
   expect(listenerMock).toHaveBeenNthCalledWith(3, {
     type: 'plugin_configured',
     target: executor,
-    version: 2,
+    version: 1,
     payload: { type: 'synchronizeStorage', options: { storageKey: '"xxx"' } },
   });
-  expect(listenerMock).toHaveBeenNthCalledWith(4, { type: 'attached', target: executor, version: 2 });
+  expect(listenerMock).toHaveBeenNthCalledWith(4, { type: 'attached', target: executor, version: 1 });
 });
 
 test('sets storage item to the initial value', () => {
@@ -226,7 +226,7 @@ test('resolves an executor when a storage item is set', () => {
     new StorageEvent('storage', {
       key: '"xxx"',
       storageArea: localStorage,
-      newValue: '{"value":"aaa","settledAt":50,"invalidatedAt":0,"annotations":{}}',
+      newValue: '{"value":"aaa","settledAt":50,"invalidatedAt":0,"annotations":{},"isFulfilled":true}',
     })
   );
 
@@ -316,14 +316,14 @@ test('restores non-empty annotations', () => {
 
   expect(listenerMock).toHaveBeenCalledTimes(4);
   expect(listenerMock).toHaveBeenNthCalledWith(1, { type: 'annotated', target: executor, version: 1 });
-  expect(listenerMock).toHaveBeenNthCalledWith(2, { type: 'fulfilled', target: executor, version: 2 });
+  expect(listenerMock).toHaveBeenNthCalledWith(2, { type: 'fulfilled', target: executor, version: 1 });
   expect(listenerMock).toHaveBeenNthCalledWith(3, {
     type: 'plugin_configured',
     target: executor,
-    version: 2,
+    version: 1,
     payload: { type: 'synchronizeStorage', options: { storageKey: '"xxx"' } },
   });
-  expect(listenerMock).toHaveBeenNthCalledWith(4, { type: 'attached', target: executor, version: 2 });
+  expect(listenerMock).toHaveBeenNthCalledWith(4, { type: 'attached', target: executor, version: 1 });
 });
 
 test('overwrites annotations', () => {


### PR DESCRIPTION
- Fewer events are published during storage sync;
- The executor state is synced if the task is aborted;
- Prevent sync loop when multiple tabs update the storage.